### PR TITLE
signal on search to update the package details

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+0.5.10 Nov 06, 2022
+ * fix issue with package details not getting updated with searches
+
 0.5.9 Feb 05, 2022
  * tx pull
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([gslapt],[0.5.9],[woodwardj@jaos.org])
+AC_INIT([gslapt],[0.5.10],[woodwardj@jaos.org])
 AC_CONFIG_SRCDIR([configure.ac])
 AM_INIT_AUTOMAKE([-Wall foreign])
 AC_CONFIG_HEADERS([config.h])

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('gslapt', 'c',
-  version: '0.5.9',
+  version: '0.5.10',
   license: 'GPLv2',
   meson_version: '>= 0.56',
   default_options: [


### PR DESCRIPTION
Reported from:
https://forum.salixos.org/viewtopic.php?f=15&t=8494&p=48518#p48518

Fire off the package details helper whenever we change the treeview filter. Empty out the details in the event we have no current selection.